### PR TITLE
Modify the publish targets of both  Makefiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,8 +52,9 @@ RUN apt-get update && apt-get -y upgrade && \
 # These environment variables may be overridden by the pegaus-build-var.env
 # file but are probably
 
-# Docker registry
+# Docker repository name and user name
 ENV DOCKER_REGISTRY=kschopmeyer
+ENV DOCKER_USER
 
 # OpenPegasus Server name and version
 ENV SERVER_IMAGE="openpegasus-server"

--- a/Makefile_wbemserver-build
+++ b/Makefile_wbemserver-build
@@ -46,11 +46,15 @@ MAKEFLAGS += --no-builtin-rules
 
 SHELL=/bin/bash
 
+# Top-level build target. This is use as target if cmd lines is "make"
+.PHONY: default-target
+default-target: build deploy
+
 .PHONY: help
 help:
 	@echo "Usage:"
 	@echo ""
-	@echo "  make all          make build deploy."
+	@echo "  make               make build deploy."
 	@echo "  make config-info   OpenPegasus build and run configuration information."
 	@echo "  make build         clone OpenPegasus compile it and execute tests."
 	@echo "      build subtargets:"
@@ -85,10 +89,6 @@ help:
 	@echo ""
 	@echo "NOTE: DOCKER_USER and DOCKER_PASSWORD are requested on publish"
 	@echo ""
-
-# Top-level build targets
-.PHONY: all
-all: build deploy
 
 build.done: checkout-repository build-server test-server
 	@echo "done" >$@
@@ -181,7 +181,7 @@ build-server: build-server.done
 # pegasus directory.
 
 .PHONY: test-server
-test-server: build-server.done
+test-server.done: build-server.done
 	@echo "Testing the server in the build container..."
 	@echo "Set Interop Namespace to root/PG_InterOp..."
 	@export PEGASUS_INTEROP_NAMESPACE="root/PG_InterOp"
@@ -199,6 +199,9 @@ test-server: build-server.done
 
 	@echo "done" >$@.done
 	@echo "Target $@ complete"
+
+.PHONY: test-server
+test-server: test_server.done
 
 # Build the CIM repository define for the OpenPegasus testsuite.  This is
 # based on the the targets defined in pegasus/TestMakefile. This defines the
@@ -256,8 +259,8 @@ docker-image-build: remove-components
 	@echo "Build docker local image (no docker repository component) image..."
 	docker build --tag ${SERVER_IMAGE}:${SERVER_IMAGE_VERSION} .
 
-.PHONY: docker-push-server-image
-docker-push-server-image:
+.PHONY: publish
+publish:
 	@echo "Pushing the built WBEM Server image to private image registry..."
 
 	docker logout

--- a/changes.rst
+++ b/changes.rst
@@ -1,4 +1,4 @@
-# OpenPegasus Change log
+# OpenPegasus Docker Change log
 
 ##Change log
 
@@ -16,29 +16,63 @@ branch: main
 
 Rewrote the Docker files and make files to accomplish the following:
 
-1. Move the build variables from Docker file to a file that is passed to the
-   docker build run command (pegasus_build.env). Thus, pegasus build
-   environment variables are attached to the the build image when the image is
-   run rather than when the image is build.
+1. Move the OpenPegasus build variables from Docker file to a file that is
+   passed to the Docker build run command (pegasus-build-vars.env). Thus,
+   pegasus build environment variables are attached to the the build image when
+   the image is run rather than when the image is build.  This includes
+   the environment variables that control the compile and test of OpenPegasus
+   and variables that control the git clone of the OpenPegasus source code, and
+   variables that control the directories for OpenPegasus clone, and build.
 
-   Note that there are a few environment variables defining the build container
-   build directories and the pegasus platform remain in the Docker file.
+   Note that there are a few environment variables defining the build container.
+   Build directory defintions and the pegasus platform environment variable
+   remain in the Docker file.
 
 2. Greatly expanded the number of environment variables available to the build
-   in the new pegasus_build.env file
+   in the new pegasus_build.env file and documentation for each of these
+   variables.
 
 3. Expanded the number of targets in the Makefile and the wbemserver-make-file
    to include more targets to make building and testing pegasus in the container
-   simpler.
+   simpler and more granular.  Note that there is help for the Makefile
+   targets for both the build and run make files using `make help`
+
+4. Change the make files to separate targets for deploy (create the local
+   image) from publish (push the locall image to the Docker repository). Deploy
+   creates a local image and publish pushes the image to the Docker repository
+   This is because we consider the publish of the
+   build and server containers as separate from the deploy/build of these
+   containers. Note that when published both containers get tagged with the
+   repository name in addition to the container name and version.
+
+4. Add publish-server-image to Dockerfile so that it does not have to be done
+   within the build container.
+
+5. Add environment variables so that OpenPegasus can be retrieved from the
+   git repository based on either git tag (i.e. a release) or on a branch
+   where the main branch is the default.  This allows building OpenPegasus
+   image from either a release tag version or from a development branch.
+
+6. Add .done files to the make files so that there is a signal for each of the
+   steps executed.
+
+7. Rewrote much of the README.md documentation to document the new and changed
+   features of this git repository.
+
+9. Added capability to run the build process for both the build image and the
+   server image either completely automatically from end to end or manually
+   where a bash terminal is started when the image starts.  This allows a
+   build or run container to execute it default targets and close without user
+   interaction (automatic) or to have the user manually execute the make
+   targets.  Thus normally the run of the build container is manual so that
+   the user can control the build and deploy process but the th run of the
+   openpegasus-server container is automatic starting the OpenPegasus WBEM
+   server when the container is started.  The environment variables for this
+   are BUILD=<auto or bash> and RUN <auto or bash>.
 
 ### Cleanup
 
-906 288 381
-
-107 853 16
-877 256 1640 ext 1131234
-
-
+1. Cleanup the comments in all of the files.
 
 ## OpenPegasusDocker 0.1.1 - Release
 


### PR DESCRIPTION
1. Add new target to Makefile to publish the openpegasus-server image.
2. Correct errors in publish with the use of DOCKER_USER and DOCKER-REGISTRY
3. Add defualt-target target at top of Makefile_wbemserver-build so that the make command without target does build deploy which then does git clone, build(compile OpenPegasus) and test.